### PR TITLE
Update axum to version 0.5.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de18bc5f2e9df8f52da03856bf40e29b747de5a84e43aefff90e3dc4a21529b"
+checksum = "c9e3356844c4d6a6d6467b8da2cffb4a2820be256f50a3a386c9d152bab31043"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
+checksum = "d9f0c0a60006f2a293d82d571f635042a72edf927539b7685bd62d361963839b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -448,6 +448,8 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/chartered-web/Cargo.toml
+++ b/chartered-web/Cargo.toml
@@ -11,7 +11,7 @@ chartered-db = { path = "../chartered-db" }
 chartered-fs = { path = "../chartered-fs" }
 chartered-types = { path = "../chartered-types" }
 
-axum = { version = "0.5", features = ["headers"] }
+axum = { version = "0.5.16", features = ["headers"] }
 base64 = "0.13"
 bcrypt = "0.13"
 bytes = "1"


### PR DESCRIPTION
Update axum to version 0.5.16 to mitigate https://rustsec.org/advisories/RUSTSEC-2022-0055.html